### PR TITLE
change to show an error for invalid postcode

### DIFF
--- a/src/main/locales/cy/postcode-search.json
+++ b/src/main/locales/cy/postcode-search.json
@@ -22,6 +22,7 @@
     "title": "Mae yna broblem",
     "blankPostcode": "Rhowch god post",
     "invalidPostcode": "Rhowch god post dilys",
+    "missingPostcodeSpace": "Rhowch god post gyda bwlch rhwng y rhan gyntaf a'r ail ran, er enghraifft SW1A 1AA",
     "scotlandPostcode": "Nid oes gennym wybodaeth am lysoedd ar gyfer y gwasanaeth hwn. Cysylltwch â Llysoedd a Thribiwnlysoedd Yr Alban i gael cymorth.",
     "scottishChildrenPostcode": "Os yw’r plentyn (neu’r plant) yn byw yn Yr Alban, byddant tu hwnt i awdurdodaeth y gwasanaeth hwn. Cysylltwch â Llysoedd a Thribiwnlysoedd Yr Alban i gael cymorth.",
     "northernIrelandPostcode": "Nid oed gennym wybodaeth am y llysoedd yng Ngogledd Iwerddon. Cysylltwch â Llysoedd a Thribiwnlysoedd Gogledd Iwerddon i gael cymorth.",

--- a/src/main/locales/en/postcode-search.json
+++ b/src/main/locales/en/postcode-search.json
@@ -22,6 +22,7 @@
     "title": "There is a problem",
     "blankPostcode": "Enter a postcode",
     "invalidPostcode": "Enter a valid postcode format",
+    "missingPostcodeSpace": "Enter a postcode with a space between the first and second parts, for example SW1A 1AA",
     "scotlandPostcode": "We do not have court information for this service. Contact the Scottish Courts and Tribunals for help.",
     "scottishChildrenPostcode": "If the child (or children) resides in Scotland they will be outside the jurisdiction for this service. Contact the Scottish Courts and Tribunals for help.",
     "northernIrelandPostcode": "We do not have court information for Northern Ireland. Contact the Northern Ireland Courts and Tribunals for help.",

--- a/src/main/utils/validationUtils.ts
+++ b/src/main/utils/validationUtils.ts
@@ -2,6 +2,7 @@ const ACTIONS = new Set(['nearest', 'documents', 'update', 'not-listed']);
 const SINGLE_LETTER_PREFIX = /^[a-z]$/i;
 
 const VALID_POSTCODE_REGEX = /^[A-Z]{1,2}\d{1,2}[A-Z]? ?\d[A-Z]{2}$/i;
+const POSTCODE_WITHOUT_SPACE_REGEX = /^[A-Z]{1,2}\d{1,2}[A-Z]?\d[A-Z]{2}$/i;
 
 const JURISDICTION_ERROR_REGEXES = {
   scotlandPostcode: /^(ZE|KW|IV|HS|PH|AB|DD|PA|FK|G\d|KY|KA|DG|TD|EH|ML)/i,
@@ -35,6 +36,8 @@ export const checkPostcode = (postcode: string): string | undefined => {
     return 'blankPostcode';
   } else if (!VALID_POSTCODE_REGEX.test(trimmedPostcode)) {
     return 'invalidPostcode';
+  } else if (POSTCODE_WITHOUT_SPACE_REGEX.test(trimmedPostcode)) {
+    return 'missingPostcodeSpace';
   }
 
   // might be in an unhandled jurisdiction

--- a/src/test/unit/controllers/PostcodeResultsController.test.ts
+++ b/src/test/unit/controllers/PostcodeResultsController.test.ts
@@ -73,6 +73,14 @@ describe('PostcodeResultsController', () => {
     expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('/search-by-postcode?error='));
   });
 
+  test('GET: redirects to search page with missing space error if postcode does not contain a space', async () => {
+    req.query = { postcode: 'SW1A1AA' };
+    req.params = {};
+    await controller.get(req as FactRequest, res);
+    expect(res.redirect).toHaveBeenCalledWith('/search-by-postcode?error=missingPostcodeSpace');
+    expect(mockPerformPostcodeOnlySearch).not.toHaveBeenCalled();
+  });
+
   test('GET: redirects to service search page with error if postcode is invalid (with service)', async () => {
     req.query = { postcode: 'bad' };
     await controller.get(req as FactRequest, res);

--- a/src/test/unit/controllers/PostcodeSearchController.test.ts
+++ b/src/test/unit/controllers/PostcodeSearchController.test.ts
@@ -74,6 +74,17 @@ describe('PostcodeSearchController', () => {
     );
   });
 
+  test('POST: renders missing space error if postcode does not contain a space', async () => {
+    calculateServiceNameFromSlugMock.mockResolvedValue('service');
+    calculateServiceAreaFromSlugMock.mockResolvedValue({ name: 'Area', nameCy: 'Ardal' } as ServiceArea);
+    req.body = { postcode: 'SW1A1AA' };
+    await controller.continue(req as FactRequest, res);
+    expect(res.render).toHaveBeenCalledWith(
+      'postcode-search',
+      expect.objectContaining({ errorType: 'missingPostcodeSpace', error: true })
+    );
+  });
+
   test('POST: redirects to /search-by-postcode/courts/near if no service search', async () => {
     req.body = { postcode: 'SW1A 1AA' };
     req.params = {};

--- a/src/test/unit/utils/validationUtils.test.ts
+++ b/src/test/unit/utils/validationUtils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { checkPostcode, isValidPostcode } from '../../../main/utils/validationUtils';
+
+describe('validationUtils', () => {
+  test('returns missingPostcodeSpace when postcode is valid except for the required space', () => {
+    expect(checkPostcode('SW1A1AA')).toBe('missingPostcodeSpace');
+    expect(isValidPostcode('SW1A1AA')).toBe(false);
+  });
+
+  test('accepts postcode when there is a space between outward and inward codes', () => {
+    expect(checkPostcode('SW1A 1AA')).toBeUndefined();
+    expect(isValidPostcode('SW1A 1AA')).toBe(true);
+  });
+
+  test('returns invalidPostcode when postcode is not structurally valid', () => {
+    expect(checkPostcode('not-a-postcode')).toBe('invalidPostcode');
+  });
+});

--- a/src/test/unit/views/pages/postcode-search.test.ts
+++ b/src/test/unit/views/pages/postcode-search.test.ts
@@ -77,6 +77,26 @@ describe('PostcodeSearch View', () => {
     expect(html).toContain(welshI18n.errorText.invalidPostcode);
   });
 
+  test('renders missing postcode space error message (English)', () => {
+    const html = env.render('postcode-search.njk', {
+      ...i18n,
+      serviceAreaLocalised,
+      error: true,
+      errorType: 'missingPostcodeSpace',
+    });
+    expect(html).toContain(i18n.errorText.missingPostcodeSpace);
+  });
+
+  test('renders missing postcode space error message (Welsh)', () => {
+    const html = env.render('postcode-search.njk', {
+      ...welshI18n,
+      serviceAreaLocalised,
+      error: true,
+      errorType: 'missingPostcodeSpace',
+    });
+    expect(html).toContain(welshI18n.errorText.missingPostcodeSpace);
+  });
+
   test('renders childcare hint when serviceAreaIsChildcare is true (English)', () => {
     const html = env.render('postcode-search.njk', {
       ...i18n,


### PR DESCRIPTION
• PR summary:

  ## Summary 

  - Added postcode validation for postcodes entered without a space between outward and inward codes, for example `SW1A1AA`.
  - Shows a GOV.UK error summary/input error instead of continuing to postcode results and displaying no results.
  - Added English and Welsh error messages for the missing postcode space case.
  - Added unit tests for validation, controller behavior, and postcode search view rendering.

  ## Tests

  - `yarn lint` passed
  - `yarn test` passed: 48 suites, 212 tests
  - `yarn test:routes` passed: 4 suites, 16 tests

  There were existing runtime warnings/logs during tests, including DEP0060 and missing /mnt/secrets/ properties in route tests, but they did not fail the checks. 🐱 